### PR TITLE
Logger.py added

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,28 @@
+import datetime
+
+logFileName = 'log.txt'
+now = datetime.datetime.now()
+
+def log(func):
+    def wrapper(*args, **qwargs):
+        try:
+            func(*args, **qwargs)
+            entry = 'Command ' + func.__name__ + ' executed at: ' + str(now) + ' with args: ' + str(func.__code__.co_varnames)
+        except Exception as error:
+            entry = 'Command ' + func.__name__ + ' failed to run at: ' + str(now) + ' with args: ' + str(func.__code__.co_varnames) + '\n---> error: '+ str(error)
+        with open(logFileName,'w') as logfile:
+            logfile.write(entry)
+        print(entry)
+    return wrapper
+
+'''
+How to use:
+1) put the decorator @log or @logger.log before the function definition
+Example:
+
+@log
+def test(*args, **qwargs):
+    #some code here...
+    return *args, **qwargs
+
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,3 +96,4 @@ yarl==1.8.2
 youtube-dl==2021.12.17
 yt-dlp==2023.3.4
 mysql-connector-python==8.0.33
+datetime==5.1


### PR DESCRIPTION
How to use:
1) put the decorator @log or @logger.log before the function definition
Example:

@log
def test(*args, **qwargs):
    #some code here...
    return *args, **qwargs